### PR TITLE
chore: use 2018-present in licence/README and remove renovate.json

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018-2026 Felippe Maurício
+Copyright (c) 2018-present Felippe Maurício
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -284,4 +284,4 @@ significant changes first. Documentation is written in Australian English (en-AU
 
 ## License
 
-MIT © 2018-2026 Felippe Maurício. See [LICENSE.md](https://github.com/felippemauricio/promise-fn-retry/blob/main/LICENSE.md).
+MIT © 2018-present Felippe Maurício. See [LICENSE.md](https://github.com/felippemauricio/promise-fn-retry/blob/main/LICENSE.md).

--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,0 @@
-{
-  "extends": ["config:base"]
-}


### PR DESCRIPTION
Follow-up to #33, which merged before these two tweaks landed.

- Switch the copyright year to **2018-present** in `LICENSE.md` and the README footer, so it never needs a yearly bump.
- Remove `renovate.json` — dependency updates are handled by Dependabot.

Docs/config only; no code changes.